### PR TITLE
Fixed nixos-rebuild switch issue

### DIFF
--- a/nixos-zfs-setup.sh
+++ b/nixos-zfs-setup.sh
@@ -248,12 +248,12 @@ tee -a ${ZFSCFG} <<-'EOF'
   '';
 
   boot.loader.grub.extraInstallCommands = ''
-    ESP_MIRROR=$(mktemp -d)
-    cp -r /boot/efi/EFI $ESP_MIRROR
+    ESP_MIRROR=$(${pkgs.coreutils}/bin/mktemp -d)
+    ${pkgs.coreutils}/bin/cp -r /boot/efi/EFI $ESP_MIRROR
     for i in /boot/efis/*; do
-      cp -r $ESP_MIRROR/EFI $i
+      ${pkgs.coreutils}/bin/cp -r $ESP_MIRROR/EFI $i
     done
-    rm -rf $ESP_MIRROR
+    ${pkgs.coreutils}/bin/rm -rf $ESP_MIRROR
   '';
 
   boot.loader.grub.devices = [


### PR DESCRIPTION
Fixes [#2](https://github.com/voidzero/nixos-zfs-setup/issues/2) install-grub.sh: line 5: mktemp: command not found